### PR TITLE
add <tbody> to render-collection, render-map

### DIFF
--- a/src-cljs/json_html/core.cljs
+++ b/src-cljs/json_html/core.cljs
@@ -16,9 +16,10 @@
   (if (empty? col)
     [:div.jh-type-object [:span.jh-empty-collection]]
     [:table.jh-type-object
+     [:tbody
       (for [[i v] (map-indexed vector col)]
         [:tr [:th.jh-key.jh-array-key i]
-             [:td.jh-value.jh-array-value (render v)]])]))
+             [:td.jh-value.jh-array-value (render v)]])]]))
 
 (defn render-set [s]
   (if (empty? s)
@@ -26,12 +27,13 @@
     [:ul (for [item s] [:li.jh-value (render item)])]))
 
 (defn render-map [m]
-    (if (empty? m)
-      [:div.jh-type-object [:span.jh-empty-map]]
-      [:table.jh-type-object
-        (for [[k v] m]
-          [:tr [:th.jh-key.jh-object-key (name k)]
-               [:td.jh-value.jh-object-value (render v)]])]))
+  (if (empty? m)
+    [:div.jh-type-object [:span.jh-empty-map]]
+    [:table.jh-type-object
+     [:tbody
+      (for [[k v] m]
+        [:tr [:th.jh-key.jh-object-key (name k)]
+             [:td.jh-value.jh-object-value (render v)]])]]))
 
 (defn render-string [s]
   [:span.jh-type-string

--- a/src/json_html/core.clj
+++ b/src/json_html/core.clj
@@ -18,7 +18,7 @@
 
   Character
   (render [this] [:span.jh-type-string (str this)])
-  
+
   Boolean
   (render [this] [:span.jh-type-bool this])
 
@@ -48,24 +48,26 @@
     (if (empty? this)
       [:div.jh-type-object [:span.jh-empty-map]]
       [:table.jh-type-object
-        (for [[k v] this]
+        [:tbody
+         (for [[k v] this]
           [:tr [:th.jh-key.jh-object-key k]
-               [:td.jh-value.jh-object-value (render v)]])]))
+               [:td.jh-value.jh-object-value (render v)]])]]))
 
   IPersistentSet
   (render [this]
     (if (empty? this)
       [:div.jh-type-set [:span.jh-empty-set]]
       [:ul (for [item this] [:li.jh-value (render item)])]))
-  
+
   IPersistentCollection
   (render [this]
     (if (empty? this)
       [:div.jh-type-object [:span.jh-empty-collection]]
       [:table.jh-type-object
-        (for [[i v] (map-indexed vector this)]
-          [:tr [:th.jh-key.jh-array-key i]
-               [:td.jh-value.jh-array-value (render v)]])]))
+        [:tbody
+          (for [[i v] (map-indexed vector this)]
+             [:tr [:th.jh-key.jh-array-key i]
+                  [:td.jh-value.jh-array-value (render v)]])]]))
 
   Object
   (render [this]


### PR DESCRIPTION
In Reagent, unwrapped child elements can cause an error on component updates (see [here](https://github.com/facebook/react/blob/9d5ab29/src/browser/ui/dom/DOMChildrenOperations.js#L117-L127))
