### PR TITLE
Make URL in strings clickable

### DIFF
--- a/src/json_html/core.clj
+++ b/src/json_html/core.clj
@@ -77,10 +77,20 @@
     [:span.jh-type-string (.toString this)]))
 
 
+(def url-regex ;; good enough...
+  (re-pattern "(\\b(https?|ftp|file|ldap)://[-A-Za-z0-9+&@#/%?=~_|!:,.;]*[-A-Za-z0-9+&@#/%=~_|])"))
+
+(defn linkify-links
+  "Make links clickable."
+  [string]
+  (clojure.string/replace string url-regex "<a class='jh-type-string-link' href=$1>$1</a>"))
+
 (defn edn->html [edn]
-  (html
-   [:div.jh-root
-    (render edn)]))
+  (-> (html
+       [:div.jh-root
+        (render edn)])
+      (linkify-links)))
+
 
 (defn json->html [json]
   (-> json (parse-string false) edn->html))


### PR DESCRIPTION
This will automatically create hyperlinks when a URL string is found.

I'm well aware the regex will not match all potential URLs (turns out to be quite the rabbit hole), but this should be good enough.