### PR TITLE
Add :key meta data to sequence elements, for react/reagent/om.

### DIFF
--- a/src-cljs/json_html/core.cljs
+++ b/src-cljs/json_html/core.cljs
@@ -21,8 +21,8 @@
     [:table.jh-type-object
      [:tbody
       (for [[i v] (map-indexed vector col)]
-        [:tr [:th.jh-key.jh-array-key i]
-             [:td.jh-value.jh-array-value (render v)]])]]))
+        ^{:key i}[:tr [:th.jh-key.jh-array-key i]
+                  [:td.jh-value.jh-array-value (render v)]])]]))
 
 (defn render-set [s]
   (if (empty? s)
@@ -41,8 +41,8 @@
     [:table.jh-type-object
      [:tbody
       (for [[k v] (sort-map m)]
-        [:tr [:th.jh-key.jh-object-key (render k)]
-             [:td.jh-value.jh-object-value (render v)]])]]))
+        ^{:key k}[:tr [:th.jh-key.jh-object-key (render k)]
+                  [:td.jh-value.jh-object-value (render v)]])]]))
 
 (defn render-string [s]
   [:span.jh-type-string


### PR DESCRIPTION
Reagent (and, I assume, also Om) want to see :key meta data associated with each element of a list.

I use json-html.core/edn->hiccup very often in my React project to create a debug view showing the full state of my data tree. This works beautifully, except for the large number of warnings generated into the browser console because of the sequences without key data.

This patch addresses the problem, and should be beneficial to anyone who uses json-html with the react-based libraries. I don't believe it should have any adverse effect for other users.